### PR TITLE
add hasSuggestions for newer eslint

### DIFF
--- a/lib/rules/one-by-one-arguments.js
+++ b/lib/rules/one-by-one-arguments.js
@@ -18,6 +18,7 @@ const meta = {
   },
 
   fixable: "code",
+  hasSuggestions: true,
 
   messages: {
     splitArguments:

--- a/lib/rules/prefer-classnames-function.js
+++ b/lib/rules/prefer-classnames-function.js
@@ -17,6 +17,7 @@ const meta = {
   },
 
   fixable: "code",
+  hasSuggestions: true,
 
   messages: {
     useFunction:


### PR DESCRIPTION
```
$ yarn eslint src/app/page.tsx
$ /path/to/projects/node_modules/.bin/eslint src/app/page.tsx

Oops! Something went wrong! :(

ESLint: 8.32.0

Error: Rules with suggestions must set the `meta.hasSuggestions` property to `true`.
Occurred while linting /path/to/projects/src/app/page.tsx:7
```

ESLint 8+ does not support rules unless they have `meta.hasSuggestions`

This PR fixes it
